### PR TITLE
Errorhandling

### DIFF
--- a/Pinpoint.Core/ErrorLogging.cs
+++ b/Pinpoint.Core/ErrorLogging.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Pinpoint.Core
+{
+    public static class ErrorLogging
+    {
+        private static readonly string ErrorLogFilePath = AppConstants.MainDirectory + "errorlog.txt";
+        public static async Task LogException(Exception e)
+        {
+            if (!File.Exists(ErrorLogFilePath))
+            {
+                File.Create(ErrorLogFilePath);
+            }
+
+            await using var streamWriter = new StreamWriter(ErrorLogFilePath, true);
+
+            var exception = e;
+
+            await streamWriter.WriteLineAsync($"Timestamp: {DateTime.Now}");
+
+            while (exception != null)
+            {
+                await streamWriter.WriteLineAsync($"{e.GetType().FullName}:");
+                await streamWriter.WriteLineAsync($"Exception message: {e.Message}");
+                await streamWriter.WriteLineAsync($"Exception stacktrace: {e.StackTrace}");
+
+                exception = exception.InnerException;
+            }
+        }
+    }
+}

--- a/Pinpoint.Core/ErrorLogging.cs
+++ b/Pinpoint.Core/ErrorLogging.cs
@@ -7,6 +7,7 @@ namespace Pinpoint.Core
     public static class ErrorLogging
     {
         private static readonly string ErrorLogFilePath = AppConstants.MainDirectory + "errorlog.txt";
+
         public static async Task LogException(Exception e)
         {
             if (!File.Exists(ErrorLogFilePath))

--- a/Pinpoint.Plugin.Bookmarks/Pinpoint.Plugin.Bookmarks.csproj
+++ b/Pinpoint.Plugin.Bookmarks/Pinpoint.Plugin.Bookmarks.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Registry">
-      <HintPath>..\..\..\..\..\..\..\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\3.1.0\ref\netcoreapp3.1\Microsoft.Win32.Registry.dll</HintPath>
+      <HintPath>C:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\3.1.0\ref\netcoreapp3.1\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
Handle errors in plugins by simply marking them as failed, and then at the end of processing, reintroduce them into the list to escape potential bad state in the plugin. This means that if e.g. the calculator example fails, the result will not be displayed. I don't know if we should have some way of displaying that an error occurred, or if this behavior is alright?