### PR TITLE
Better activation of finance and Spotify plugins

### DIFF
--- a/Pinpoint.Plugin.Finance/FinancePlugin.cs
+++ b/Pinpoint.Plugin.Finance/FinancePlugin.cs
@@ -29,7 +29,7 @@ namespace Pinpoint.Plugin.Finance
             }
 
             var ticker = query.Parts[0].Substring(1);
-            return ticker.All(ch => char.IsLetter(ch) || ch == '.') && ticker.Count(char.IsLetter) >= 2;
+            return ticker.All(ch => char.IsLetter(ch) || ch == '.' || ch == '^') && ticker.Count(char.IsLetter) >= 2;
         }
 
         public async IAsyncEnumerable<AbstractQueryResult> Process(Query query)

--- a/Pinpoint.Plugin.Spotify/SpotifyPlugin.cs
+++ b/Pinpoint.Plugin.Spotify/SpotifyPlugin.cs
@@ -15,7 +15,7 @@ namespace PinPoint.Plugin.Spotify
         private readonly SpotifyClient _spotifyClient = SpotifyClient.GetInstance();
         private bool _isAuthenticated;
 
-        public PluginMeta Meta { get; set; } = new PluginMeta("Spotify Controller");
+        public PluginMeta Meta { get; set; } = new PluginMeta("Spotify Controller", PluginPriority.Highest);
 
         public PluginSettings UserSettings { get; set; } = new PluginSettings();
 


### PR DESCRIPTION
Allow searching for '^' in stock tickers, used to identify indices. Increase Spotify priority.