### PR TITLE
Set plugin enabled/disabled from saved settings

### DIFF
--- a/Pinpoint.Core/PluginEngine.cs
+++ b/Pinpoint.Core/PluginEngine.cs
@@ -30,11 +30,16 @@ namespace Pinpoint.Core
             }
 
             var plugins = AppSettings.GetOrDefault("plugins", new EmptyPlugin[0]);
+
             var match = plugins.FirstOrDefault(p => p.Meta.Name.Equals(toAdd.Meta.Name));
-            if (match != default)
+
+            if (match == null)
             {
-                toAdd.UserSettings = match.UserSettings;
+                return;
             }
+
+            toAdd.UserSettings = match.UserSettings;
+            toAdd.Meta.Enabled = match.Meta.Enabled;
 
             Plugins.Add(toAdd);
 
@@ -61,6 +66,7 @@ namespace Pinpoint.Core
         public async IAsyncEnumerable<AbstractQueryResult> Process(Query query, [EnumeratorCancellation] CancellationToken ct)
         {
             var enabledPlugins = Plugins.Where(p => p.Meta.Enabled && p.IsLoaded).ToList();
+
             for (int i = 0, numResults = 0; i < enabledPlugins.Count && numResults < 20 && !ct.IsCancellationRequested; i++)
             {
                 var plugin = enabledPlugins[i];

--- a/Pinpoint.Core/PluginEngine.cs
+++ b/Pinpoint.Core/PluginEngine.cs
@@ -30,9 +30,7 @@ namespace Pinpoint.Core
             }
 
             var plugins = AppSettings.GetOrDefault("plugins", new EmptyPlugin[0]);
-
             var match = plugins.FirstOrDefault(p => p.Meta.Name.Equals(toAdd.Meta.Name));
-
             if (match != null)
             {
                 toAdd.UserSettings = match.UserSettings;
@@ -64,7 +62,6 @@ namespace Pinpoint.Core
         public async IAsyncEnumerable<AbstractQueryResult> Process(Query query, [EnumeratorCancellation] CancellationToken ct)
         {
             var enabledPlugins = Plugins.Where(p => p.Meta.Enabled && p.IsLoaded).ToList();
-
             for (int i = 0, numResults = 0; i < enabledPlugins.Count && numResults < 20 && !ct.IsCancellationRequested; i++)
             {
                 var plugin = enabledPlugins[i];

--- a/Pinpoint.Core/PluginEngine.cs
+++ b/Pinpoint.Core/PluginEngine.cs
@@ -33,13 +33,11 @@ namespace Pinpoint.Core
 
             var match = plugins.FirstOrDefault(p => p.Meta.Name.Equals(toAdd.Meta.Name));
 
-            if (match == null)
+            if (match != null)
             {
-                return;
+                toAdd.UserSettings = match.UserSettings;
+                toAdd.Meta.Enabled = match.Meta.Enabled;
             }
-
-            toAdd.UserSettings = match.UserSettings;
-            toAdd.Meta.Enabled = match.Meta.Enabled;
 
             Plugins.Add(toAdd);
 


### PR DESCRIPTION
Settings were in fact being saved, but the 'Enabled' property was not being carried over from the settings read from disk. Closes #106 