### PR TITLE
Fix bug in AppSearch when an empty variation part appears

### DIFF
--- a/Pinpoint.Plugin.AppSearch/AppSearchPlugin.cs
+++ b/Pinpoint.Plugin.AppSearch/AppSearchPlugin.cs
@@ -47,8 +47,11 @@ namespace Pinpoint.Plugin.AppSearch
                 // Support "Visual Studio Code" -> "VSC"
                 if (variations.Length > 1)
                 {
-                    var fuzz = string.Join(',', variations.Select(part => part[0]).ToArray()).Replace(",", "");
-                    _trie.Add(fuzz, file);
+                    var appAcronymLetters = variations.Where(part => part.Length > 0)
+                        .Select(part => part[0])
+                        .ToArray();
+                    var acronym = string.Join(',', appAcronymLetters).Replace(",", "");
+                    _trie.Add(acronym, file);
                 }
             }
 
@@ -81,7 +84,7 @@ namespace Pinpoint.Plugin.AppSearch
             AppSearchFrequency.Reset();
         }
 
-        public async Task<bool> Activate(Query query) =>  query.RawQuery.Length >= 2;
+        public async Task<bool> Activate(Query query) => query.RawQuery.Length >= 2;
 
         public async IAsyncEnumerable<AbstractQueryResult> Process(Query query, [EnumeratorCancellation] CancellationToken ct)
         {


### PR DESCRIPTION
When a given variation part was length 0, `AppSearchPlugin.TryLoad()` would throw a `System.IndexOutOfRangeException`. This prevented Pinpoint from loading the plugin, keeping it stuck on the "Loading Plugins..." message indefinitely. 

Partially fixes #133. There's still the underlying issue that an exception in any plugin's TryLoad will soft lock Pinpoint entirely.