### PR TITLE
Handle application stalling if any TryLoad throws exception

### DIFF
--- a/Pinpoint.Core/PluginEngine.cs
+++ b/Pinpoint.Core/PluginEngine.cs
@@ -20,9 +20,22 @@ namespace Pinpoint.Core
             @new.Restore();
 
             // Ensure plugin hasn't been added and that it was able to load
-            if (Plugins.Contains(@new) || !await @new.TryLoad())
+            if (Plugins.Contains(@new))
             {
-                return;
+                try
+                {
+                    var pluginLoaded = await @new.TryLoad();
+
+                    if (!pluginLoaded)
+                    {
+                        return;
+                    }
+                }   
+                catch
+                {
+                    // Plugin threw an exception while loading, so don't add it.
+                    return;
+                }
             }
 
             Plugins.Add(@new);

--- a/Pinpoint.Core/PluginEngine.cs
+++ b/Pinpoint.Core/PluginEngine.cs
@@ -22,22 +22,24 @@ namespace Pinpoint.Core
             // Ensure plugin hasn't been added and that it was able to load
             if (Plugins.Contains(@new))
             {
-                try
-                {
-                    var pluginLoaded = await @new.TryLoad();
-
-                    if (!pluginLoaded)
-                    {
-                        return;
-                    }
-                }   
-                catch
-                {
-                    // Plugin threw an exception while loading, so don't add it.
-                    return;
-                }
+                return;
             }
 
+            try
+            {
+                var pluginLoaded = await @new.TryLoad();
+
+                if (!pluginLoaded)
+                {
+                    return;
+                }
+            }   
+            catch
+            {
+                // Plugin threw an exception while loading, so don't add it.
+                return;
+            }
+            
             Plugins.Add(@new);
 
             Listeners.ForEach(listener => listener.PluginChange_Added(this, @new, null));

--- a/Pinpoint.Plugin.AppSearch/UwpAppProvider.cs
+++ b/Pinpoint.Plugin.AppSearch/UwpAppProvider.cs
@@ -37,11 +37,15 @@ namespace Pinpoint.Plugin.AppSearch
                 // Separate the folder and the icon name
                 var location = package.IconLocation as string;
                 var idxOfLastDir = location.LastIndexOf("\\");
-                var iconName = location[(idxOfLastDir + 1)..];
-                var iconLocation = location[..idxOfLastDir];
 
-                iconLocation = package.InstallLocation + "\\" + iconLocation;
-                app.IconLocation = FindCorrectIconPath(iconLocation, iconName[..iconName.IndexOf(".")]);
+                if (idxOfLastDir >= 0)
+                {
+                    var iconName = location[(idxOfLastDir + 1)..];
+                    var iconLocation = location[..idxOfLastDir];
+
+                    iconLocation = package.InstallLocation + "\\" + iconLocation;
+                    app.IconLocation = FindCorrectIconPath(iconLocation, iconName[..iconName.IndexOf(".")]);
+                }
             }
         }
 

--- a/Pinpoint.Plugin.UrlLauncher/UrlLauncherPlugin.cs
+++ b/Pinpoint.Plugin.UrlLauncher/UrlLauncherPlugin.cs
@@ -25,7 +25,6 @@ namespace Pinpoint.Plugin.UrlLauncher
 
         public Task<bool> TryLoad()
         {
-            throw new NotImplementedException();
             var asm = GetType().Assembly;
 
             using var stream = asm.GetManifestResourceStream("Pinpoint.Plugin.UrlLauncher.tlds.txt");

--- a/Pinpoint.Plugin.UrlLauncher/UrlLauncherPlugin.cs
+++ b/Pinpoint.Plugin.UrlLauncher/UrlLauncherPlugin.cs
@@ -25,6 +25,7 @@ namespace Pinpoint.Plugin.UrlLauncher
 
         public Task<bool> TryLoad()
         {
+            throw new NotImplementedException();
             var asm = GetType().Assembly;
 
             using var stream = asm.GetManifestResourceStream("Pinpoint.Plugin.UrlLauncher.tlds.txt");


### PR DESCRIPTION
Fixes #135 

Handle TryLoad throwing an exception the same way we handle it returning false. Perhaps we should add a separate issue for displaying some information to the user that a plugin failed to load.

Besides this, I could not start pinpoint due to an exception thrown from the UwpAppProvider. The idxOfLastDir variable resolved to -1 for python installed via Windows Store, so I've added a check so we only add icons when the index is valid.