### PR TITLE
Fix window positioning issues caused by absolute pixel values

### DIFF
--- a/Pinpoint.Win/Utils/WindowPositionHelper.cs
+++ b/Pinpoint.Win/Utils/WindowPositionHelper.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Forms;
+
+namespace Pinpoint.Win.Utils
+{
+    public class WindowPositionHelper
+    {
+        public WindowOffset CalculateWindowOffsetFromOffsetRatios(WindowOffsetRatio windowOffsetRatio)
+        {
+            var activeScreen = Screen.FromPoint(Cursor.Position);
+
+            var activeScreenLeftOffset = activeScreen.Bounds.Width * windowOffsetRatio.LeftOffsetRatio;
+            var totalLeftOffset = activeScreen.Bounds.Left + activeScreenLeftOffset;
+
+            var activeScreenTopOffset = activeScreen.Bounds.Height * windowOffsetRatio.TopOffsetRatio;
+            var totalTopOffset = activeScreen.Bounds.Top + activeScreenTopOffset;
+
+            return new WindowOffset(totalLeftOffset, totalTopOffset);
+        }
+
+        public WindowOffsetRatio CalculateWindowOffsetRatioFromPoint(Point windowPosition)
+        {
+            var activeScreen = Screen.FromPoint(Cursor.Position);
+
+            var leftOffset = activeScreen.Bounds.Left + windowPosition.X;
+            var topOffset = activeScreen.Bounds.Top + windowPosition.Y;
+
+            var deltaWidth = Math.Abs(Math.Abs(activeScreen.Bounds.Right) - Math.Abs(leftOffset));
+            var deltaHeight = Math.Abs(Math.Abs(activeScreen.Bounds.Bottom) - Math.Abs(topOffset));
+
+            var leftOffsetRatio = deltaWidth / activeScreen.Bounds.Width;
+            var topOffsetRatio = deltaHeight / activeScreen.Bounds.Height;
+
+            return new WindowOffsetRatio(1 - leftOffsetRatio, 1 - topOffsetRatio);
+        }
+
+        public WindowOffsetRatio CalculateWindowOffsetRatioFromWindowBounds(double windowBoundsLeft, double windowBoundsTop)
+        {
+            var activeScreen = Screen.FromPoint(Cursor.Position);
+
+            var deltaWidth = Math.Abs(Math.Abs(activeScreen.Bounds.Right) - Math.Abs(windowBoundsLeft));
+            var deltaHeight = Math.Abs(Math.Abs(activeScreen.Bounds.Bottom) - Math.Abs(windowBoundsTop));
+
+            var leftOffsetRatio = 1 - (deltaWidth / activeScreen.Bounds.Width);
+            var topOffsetRatio = 1 - (deltaHeight / activeScreen.Bounds.Height);
+
+            return new WindowOffsetRatio(leftOffsetRatio, topOffsetRatio);
+        }
+    }
+
+
+    public record WindowOffset(double Left, double Top);
+    public record WindowOffsetRatio(double LeftOffsetRatio, double TopOffsetRatio);
+}

--- a/Pinpoint.Win/Utils/WindowPositionHelper.cs
+++ b/Pinpoint.Win/Utils/WindowPositionHelper.cs
@@ -49,7 +49,7 @@ namespace Pinpoint.Win.Utils
         }
     }
 
-
     public record WindowOffset(double Left, double Top);
+
     public record WindowOffsetRatio(double LeftOffsetRatio, double TopOffsetRatio);
 }

--- a/Pinpoint.Win/Views/MainWindow.xaml.cs
+++ b/Pinpoint.Win/Views/MainWindow.xaml.cs
@@ -47,6 +47,7 @@ using WK.Libraries.SharpClipboardNS;
 using Control = System.Windows.Forms.Control;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using MessageBox = System.Windows.MessageBox;
+using Pinpoint.Win.Utils;
 
 namespace Pinpoint.Win.Views
 {
@@ -59,6 +60,7 @@ namespace Pinpoint.Win.Views
         private int _showingOptionsForIndex = -1;
         private double _leftOffsetRatio = 0, _topOffsetRatio = 0;
         private Point _defaultWindowPosition;
+        private WindowPositionHelper _windowPositionHelper = new WindowPositionHelper();
 
         public MainWindow()
         {
@@ -191,16 +193,10 @@ namespace Pinpoint.Win.Views
             }
             else
             {
-                var activeScreen = Screen.FromPoint(System.Windows.Forms.Cursor.Position);
+                var windowOffset = _windowPositionHelper.CalculateWindowOffsetFromOffsetRatios(new WindowOffsetRatio(_leftOffsetRatio, _topOffsetRatio));
 
-                var activeScreenLeftOffset = activeScreen.Bounds.Width * _leftOffsetRatio;
-                var totalLeftOffset = activeScreen.Bounds.Left + activeScreenLeftOffset;
-
-                var activeScreenTopOffset = activeScreen.Bounds.Height * _topOffsetRatio;
-                var totalTopOffset = activeScreen.Bounds.Top + activeScreenTopOffset;
-
-                Left = totalLeftOffset;
-                Top = totalTopOffset;
+                Left = windowOffset.Left;
+                Top = windowOffset.Top;
 
                 Show();
                 Activate();
@@ -227,8 +223,11 @@ namespace Pinpoint.Win.Views
             // Locate window horizontal center near top of screen
             Left = _defaultWindowPosition.X;
             Top = _defaultWindowPosition.Y;
-            _leftOffsetRatio = 0.5;
-            _topOffsetRatio = 0.5;
+
+            var defaultOffsetRatio = _windowPositionHelper.CalculateWindowOffsetRatioFromPoint(_defaultWindowPosition);
+
+            _leftOffsetRatio = defaultOffsetRatio.LeftOffsetRatio;
+            _topOffsetRatio = defaultOffsetRatio.TopOffsetRatio;
         }
 
         private Point ComputeDpiAwareWindowCenterPosition(Screen screen = null)
@@ -580,16 +579,10 @@ namespace Pinpoint.Win.Views
             {
                 DragMove();
 
-                var activeScreen = Screen.FromPoint(System.Windows.Forms.Cursor.Position);
+                var windowOffsetRatio = _windowPositionHelper.CalculateWindowOffsetRatioFromWindowBounds(new WindowBounds(Left, Top));
 
-                var deltaWidth = Math.Abs(Math.Abs(activeScreen.Bounds.Right) - Math.Abs(Left));
-                var deltaHeight = Math.Abs(Math.Abs(activeScreen.Bounds.Bottom) - Math.Abs(Top));
-
-                var leftOffsetRatio = deltaWidth / activeScreen.Bounds.Width;
-                var topOffsetRatio = deltaHeight / activeScreen.Bounds.Height;
-
-                _leftOffsetRatio = 1 - leftOffsetRatio;
-                _topOffsetRatio = 1 - topOffsetRatio;
+                _leftOffsetRatio = windowOffsetRatio.LeftOffsetRatio;
+                _topOffsetRatio = windowOffsetRatio.TopOffsetRatio;
             }
         }
 

--- a/Pinpoint.Win/Views/MainWindow.xaml.cs
+++ b/Pinpoint.Win/Views/MainWindow.xaml.cs
@@ -61,7 +61,7 @@ namespace Pinpoint.Win.Views
         private int _showingOptionsForIndex = -1;
         private double _leftOffsetRatio = 0, _topOffsetRatio = 0;
         private Point _defaultWindowPosition;
-        private WindowPositionHelper _windowPositionHelper = new WindowPositionHelper();
+        private readonly WindowPositionHelper _windowPositionHelper = new();
 
         public MainWindow()
         {

--- a/Pinpoint.Win/Views/MainWindow.xaml.cs
+++ b/Pinpoint.Win/Views/MainWindow.xaml.cs
@@ -255,8 +255,7 @@ namespace Pinpoint.Win.Views
 
         private Point ComputeDpiAwareWindowCenterPosition(Screen screen = null)
         {
-            if (screen == null)
-                screen = Screen.PrimaryScreen;
+            screen ??= Screen.PrimaryScreen;
 
             var dpi = VisualTreeHelper.GetDpi(this);
 

--- a/Pinpoint.Win/Views/MainWindow.xaml.cs
+++ b/Pinpoint.Win/Views/MainWindow.xaml.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Interop;
@@ -44,13 +43,10 @@ using Pinpoint.Plugin.Translate;
 using Pinpoint.Plugin.UrlLauncher;
 using Pinpoint.Plugin.Weather;
 using Pinpoint.Win.Annotations;
-using Pinpoint.Win.Extensions;
 using WK.Libraries.SharpClipboardNS;
-using Xceed.Wpf.Toolkit;
 using Control = System.Windows.Forms.Control;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using MessageBox = System.Windows.MessageBox;
-using MouseEventArgs = System.Windows.Input.MouseEventArgs;
 
 namespace Pinpoint.Win.Views
 {
@@ -208,17 +204,15 @@ namespace Pinpoint.Win.Views
 
         private async void Window_Loaded(object sender, RoutedEventArgs e)
         {
-            _defaultWindowPosition = ComputeDefaultWindowPosition();
+            _defaultWindowPosition = ComputeDpiAwareWindowCenterPosition();
+
             MoveWindowToDefaultPosition();
 
             await LoadPlugins();
             
-            Dispatcher.Invoke(() =>
-            {
-                Model.Watermark = "Pinpoint";
-                TxtQuery.IsEnabled = true;
-                TxtQuery.Focus();
-            });
+            Model.Watermark = "Pinpoint";
+            TxtQuery.IsEnabled = true;
+            TxtQuery.Focus();
         }
 
         public void MoveWindowToDefaultPosition()
@@ -226,10 +220,25 @@ namespace Pinpoint.Win.Views
             // Locate window horizontal center near top of screen
             Left = _defaultWindowPosition.X;
             Top = _defaultWindowPosition.Y;
-            _offsetFromDefaultX = _offsetFromDefaultY = 0;
+            _offsetFromDefaultX = 0;
+            _offsetFromDefaultY = 0;
         }
 
-        private Point ComputeDefaultWindowPosition() => new(SystemParameters.PrimaryScreenWidth / 2 - Width / 2, SystemParameters.PrimaryScreenHeight / 5);
+        private Point ComputeDpiAwareWindowCenterPosition()
+        {
+            var dpi = VisualTreeHelper.GetDpi(this);
+
+            var screenWidth = SystemParameters.PrimaryScreenWidth;
+            var screenHeight = SystemParameters.PrimaryScreenHeight;
+
+            var windowWidth = (int)(Width * dpi.DpiScaleX);
+            var windowHeight = (int)(Height * dpi.DpiScaleY);
+
+            var x = (screenWidth / 2) - (windowWidth / 2);
+            var y = (screenHeight / 5) + (windowHeight / 2);
+
+            return new Point(x, y);
+        }
 
         protected override void OnClosing(CancelEventArgs e)
         {

--- a/Pinpoint.Win/Views/MainWindow.xaml.cs
+++ b/Pinpoint.Win/Views/MainWindow.xaml.cs
@@ -579,7 +579,7 @@ namespace Pinpoint.Win.Views
             {
                 DragMove();
 
-                var windowOffsetRatio = _windowPositionHelper.CalculateWindowOffsetRatioFromWindowBounds(new WindowBounds(Left, Top));
+                var windowOffsetRatio = _windowPositionHelper.CalculateWindowOffsetRatioFromWindowBounds(Left, Top);
 
                 _leftOffsetRatio = windowOffsetRatio.LeftOffsetRatio;
                 _topOffsetRatio = windowOffsetRatio.TopOffsetRatio;


### PR DESCRIPTION
Now calculates the ratio at which the window is displaced from the left and top of the current window rather than store absolute pixel values. 
The issue with that was that, when dragging the window from one screen to another, the offset would end up being that of an entire screen, placing the window outside the screen when visibility was then toggled again. 
This way, the window should appear with the exact same relative offset, regardless of screen resolution and whether or not the window is dragged within one screen or from one screen to another.

Closes #119 