### PR TITLE
Fix URL shortcut launch issue on Windows 11

### DIFF
--- a/Pinpoint.Plugin.Shortcuts/ShortcutsPlugin.cs
+++ b/Pinpoint.Plugin.Shortcuts/ShortcutsPlugin.cs
@@ -28,12 +28,7 @@ namespace Pinpoint.Plugin.Shortcuts
 
         public async Task<bool> Activate(Query query)
         {
-            if (query.Parts.Length == 2)
-            {
-                return Storage.UserSettings.Any(s => s.Name.Equals(query.Parts[0]));
-            }
-            
-            return Storage.UserSettings.Any(s => s.Name.Equals(query.RawQuery) && !s.Value.ToString()!.Contains("query"));
+            return Storage.UserSettings.Any(s => s.Name.Equals(query.Parts[0]));
         }
 
         public async IAsyncEnumerable<AbstractQueryResult> Process(Query query, CancellationToken ct)

--- a/Pinpoint.Plugin.Shortcuts/ShortcutsPlugin.cs
+++ b/Pinpoint.Plugin.Shortcuts/ShortcutsPlugin.cs
@@ -13,7 +13,7 @@ namespace Pinpoint.Plugin.Shortcuts
         private static readonly string Description = $"Create custom shortcuts to open file locations, settings and even websites.\n\nExamples:\nName: youtube; Value: https://youtube.com,\nName: desktop; Value: C:\\Users\\{Environment.UserName}\\Desktop,\nName: apps; Value: ms-settings:appsfeatures, \nName: desktop; Value: C:\\Users\\{Environment.UserName}\\Desktop,\nName: reddit; Value: https://www.reddit.com/r/{{query}}";
 
         public PluginMeta Meta { get; set; } = new("Shortcuts", Description, PluginPriority.Highest);
-        
+
         public PluginStorage Storage { get; set; } = new();
 
         public bool ModifiableSettings => true;
@@ -33,18 +33,15 @@ namespace Pinpoint.Plugin.Shortcuts
 
         public async IAsyncEnumerable<AbstractQueryResult> Process(Query query, CancellationToken ct)
         {
-            ShortcutsResult result;
             if (query.Parts.Length == 1)
             {
-                result = new ShortcutsResult(query.RawQuery, Storage.UserSettings.Str(query.RawQuery));
-            }
-            else
-            {
-                var q = query.Parts;
-                result = new ShortcutsResult(q[0], Storage.UserSettings.Str(q[0]).Replace("{query}", q[1]));
+                yield return new ShortcutsResult(query.RawQuery, Storage.UserSettings.Str(query.RawQuery));
+                yield break;
             }
 
-            yield return result;
+            var q = query.Parts;
+            var shortcut = Storage.UserSettings.Str(q[0]).Replace("{query}", q[1]);
+            yield return new ShortcutsResult(q[0], shortcut);
         }
     }
 }

--- a/Pinpoint.Plugin.Shortcuts/ShortcutsResult.cs
+++ b/Pinpoint.Plugin.Shortcuts/ShortcutsResult.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.Drawing;
 using FontAwesome5;
@@ -18,6 +19,17 @@ namespace Pinpoint.Plugin.Shortcuts
 
         public override void OnSelect()
         {
+            var isUrl = Uri.TryCreate(_shortcut, UriKind.Absolute, out Uri uriResult) && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
+            if (isUrl)
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = uriResult.AbsoluteUri,
+                    UseShellExecute = true
+                });
+                return;
+            }
+
             Process.Start("explorer.exe", _shortcut);
         }
     }


### PR DESCRIPTION
- Always activate shortcuts on trigger keyword
- Explicitly launch URL shortcuts
