### PR TITLE
Spotify plugin no longer just spawns sign-in out of nowhere.

### DIFF
--- a/Pinpoint.Plugin.Spotify/AuthenticationManager.cs
+++ b/Pinpoint.Plugin.Spotify/AuthenticationManager.cs
@@ -43,6 +43,7 @@ namespace PinPoint.Plugin.Spotify
             var authCode = ctx.Request.QueryString["code"];
 
             server.Stop();
+
             return await ExchangeAuthCodeForToken(authCode);
         }
 

--- a/Pinpoint.Plugin.Spotify/ChangeTrackResult.cs
+++ b/Pinpoint.Plugin.Spotify/ChangeTrackResult.cs
@@ -1,4 +1,5 @@
-﻿using FontAwesome5;
+﻿using System.Threading.Tasks;
+using FontAwesome5;
 using Pinpoint.Core.Results;
 using Pinpoint.Plugin.Spotify.Client;
 
@@ -6,21 +7,24 @@ namespace PinPoint.Plugin.Spotify
 {
     public class ChangeTrackResult: AbstractFontAwesomeQueryResult
     {
+        private readonly SpotifyClient _spotifyClient;
         private readonly string _keyword;
 
-        public ChangeTrackResult(string keyword): base(keyword == "skip" || keyword == "next" ? "Next track" : "Previous track")
+        public ChangeTrackResult(SpotifyClient spotifyClient, string keyword): base(keyword == "skip" || keyword == "next" ? "Next track" : "Previous track")
         {
+            _spotifyClient = spotifyClient;
             _keyword = keyword;
         }
+
         public override void OnSelect()
         {
             if (_keyword == "skip" || _keyword == "next")
             {
-                SpotifyClient.GetInstance().NextTrack();
+                Task.Run(() =>_spotifyClient.NextTrack());
             }
             else
             {
-                SpotifyClient.GetInstance().PreviousTrack();
+                Task.Run(() => _spotifyClient.PreviousTrack());
             }
         }
 

--- a/Pinpoint.Plugin.Spotify/Client/SpotifyRefreshTokenClient.cs
+++ b/Pinpoint.Plugin.Spotify/Client/SpotifyRefreshTokenClient.cs
@@ -1,0 +1,33 @@
+using PinPoint.Plugin.Spotify;
+
+namespace Pinpoint.Plugin.Spotify.Client
+{
+    
+    public interface ISpotifyRefreshTokenClient
+    {
+        string GetRefreshToken();
+        void SaveRefreshToken(string refreshToken);
+    }
+
+    public class SpotifyRefreshTokenClient : ISpotifyRefreshTokenClient
+    {
+        private readonly SpotifyPlugin _spotifyPlugin;
+        public SpotifyRefreshTokenClient(SpotifyPlugin spotifyPlugin)
+        {
+            _spotifyPlugin = spotifyPlugin;
+        }
+
+        public string GetRefreshToken()
+        {
+            var refreshToken = _spotifyPlugin.Storage.Internal["refresh_token"].ToString();
+            
+            return refreshToken;
+        }
+
+        public void SaveRefreshToken(string refreshToken)
+        {
+            _spotifyPlugin.Storage.Internal["refresh_token"] = refreshToken;
+            _spotifyPlugin.Save();
+        }
+    }
+}

--- a/Pinpoint.Plugin.Spotify/PlayPauseResult.cs
+++ b/Pinpoint.Plugin.Spotify/PlayPauseResult.cs
@@ -6,10 +6,16 @@ namespace PinPoint.Plugin.Spotify
 {
     public class PlayPauseResult: AbstractFontAwesomeQueryResult
     {
-        public PlayPauseResult(): base("Play/pause current track") { }
+        private readonly SpotifyClient _spotifyClient;
+
+        public PlayPauseResult(SpotifyClient spotifyClient): base("Play/pause current track") 
+        { 
+            _spotifyClient = spotifyClient;
+        }
+
         public override void OnSelect()
         {
-            SpotifyClient.GetInstance().PlayPauseCurrentTrack();
+            _ = _spotifyClient.PlayPauseCurrentTrack();
         }
 
         public override EFontAwesomeIcon FontAwesomeIcon => EFontAwesomeIcon.Brands_Spotify;

--- a/Pinpoint.Plugin.Spotify/SpotifyPlugin.cs
+++ b/Pinpoint.Plugin.Spotify/SpotifyPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +19,6 @@ namespace PinPoint.Plugin.Spotify
         private SpotifyClient _spotifyClient;
         // TODO: Add event/callback so authentication manager can set _isAuthenticated 
         private bool _isAuthenticated;
-
         public override PluginManifest Manifest { get; } = new("Spotify Controller", PluginPriority.High)
         {
             Description = "Control any Spotify session without leaving your workflow. Requires sign-in on first use.\n\nExamples: \"album <name>\", \"artist <name>\", \"episode <name>\", \"play <name>\", \"playlist <name>\", \"show <name>\", \"skip\", \"next\", \"prev\", \"back\", \"pause\""
@@ -98,7 +98,7 @@ namespace PinPoint.Plugin.Spotify
         {
             if (!_isAuthenticated)
             {
-                return new UnauthenticatedResult(_authManager, _spotifyClient);
+                return new UnauthenticatedResult(_authManager, _spotifyClient, () => { _isAuthenticated = true; });
             }
             else
             {

--- a/Pinpoint.Plugin.Spotify/SpotifyPlugin.cs
+++ b/Pinpoint.Plugin.Spotify/SpotifyPlugin.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Pinpoint.Core.Results;
 using Pinpoint.Plugin;
 using Pinpoint.Plugin.Spotify.Client;
 
@@ -15,6 +16,7 @@ namespace PinPoint.Plugin.Spotify
         };
         private readonly AuthenticationManager _authManager = new();
         private SpotifyClient _spotifyClient;
+        // TODO: Add event/callback so authentication manager can set _isAuthenticated 
         private bool _isAuthenticated;
 
         public override PluginManifest Manifest { get; } = new("Spotify Controller", PluginPriority.High)
@@ -34,31 +36,13 @@ namespace PinPoint.Plugin.Spotify
             return Task.FromResult(_isAuthenticated);
         }
 
-        public override async Task<bool> ShouldActivate(Query query)
+        public override Task<bool> ShouldActivate(Query query)
         {
             var queryParts = query.Raw.Split(new[] { ' ' }, 2);
 
             var shouldActivate = queryParts.Length > 0 && _keywords.Contains(queryParts[0]);
 
-            switch (shouldActivate)
-            {
-                case false:
-                    return false;
-
-                case true when !_isAuthenticated:
-                    {
-                        var tokens = await _authManager.Authenticate();
-                        if (tokens?.access_token != null && tokens.refresh_token != null)
-                        {
-                            await _spotifyClient.InitializeClientWithTokens(tokens);
-                            _isAuthenticated = true;
-                        }
-
-                        break;
-                    }
-            }
-
-            return _isAuthenticated;
+            return Task.FromResult(shouldActivate);
         }
 
         public override async IAsyncEnumerable<AbstractQueryResult> ProcessQuery(Query query, [EnumeratorCancellation] CancellationToken ct)
@@ -68,11 +52,11 @@ namespace PinPoint.Plugin.Spotify
             if (queryParts[0] == "skip" || queryParts[0] == "next" ||
                 queryParts[0] == "prev" || queryParts[0] == "back")
             {
-                yield return new ChangeTrackResult(_spotifyClient, queryParts[0]);
+                yield return CreateResultOrUnauthenticated(new ChangeTrackResult(_spotifyClient, queryParts[0]));
                 yield break;
             }
 
-            yield return new PlayPauseResult(_spotifyClient);
+            yield return CreateResultOrUnauthenticated(new PlayPauseResult(_spotifyClient));
 
             var isSearchQuery = queryParts.Length > 1 &&
                                 queryParts[1].Length > 3 &&
@@ -94,7 +78,7 @@ namespace PinPoint.Plugin.Spotify
 
             foreach (var searchResult in searchResults)
             {
-                yield return new SpotifySearchResult(_spotifyClient, searchResult.DisplayString, searchResult.Uri, searchResult.Type);
+                yield return CreateResultOrUnauthenticated(new SpotifySearchResult(_spotifyClient, searchResult.DisplayString, searchResult.Uri, searchResult.Type));
             }
         }
 
@@ -107,6 +91,18 @@ namespace PinPoint.Plugin.Spotify
 
                 default:
                     return new[] { type };
+            }
+        }
+
+        private AbstractFontAwesomeQueryResult CreateResultOrUnauthenticated(AbstractFontAwesomeQueryResult result)
+        {
+            if (!_isAuthenticated)
+            {
+                return new UnauthenticatedResult(_authManager, _spotifyClient);
+            }
+            else
+            {
+                return result;
             }
         }
     }

--- a/Pinpoint.Plugin.Spotify/SpotifySearchResult.cs
+++ b/Pinpoint.Plugin.Spotify/SpotifySearchResult.cs
@@ -6,12 +6,14 @@ namespace PinPoint.Plugin.Spotify
 {
     public class SpotifySearchResult : AbstractFontAwesomeQueryResult
     {
+        private readonly SpotifyClient _spotifyClient;
         private readonly string _type;
 
-        public SpotifySearchResult(string result, string uri, string type) : base(result, $"{char.ToUpper(type[0]) + type[1..]} on Spotify")
+        public SpotifySearchResult(SpotifyClient spotifyClient, string result, string uri, string type) : base(result, $"{char.ToUpper(type[0]) + type[1..]} on Spotify")
         {
+            _spotifyClient = spotifyClient;
             Uri = uri;
-            Options.Add(new QueueOption("Queue", uri));
+            Options.Add(new QueueOption(_spotifyClient, "Queue", uri));
             _type = type;
         }
 
@@ -21,33 +23,38 @@ namespace PinPoint.Plugin.Spotify
 
         public override async void OnSelect()
         {
-            if (!await SpotifyClient.GetInstance().IsCurrentlyPlaying())
+            if (!await _spotifyClient.IsCurrentlyPlaying())
             {
-                await SpotifyClient.GetInstance().PlayPauseCurrentTrack();
+                await _spotifyClient.PlayPauseCurrentTrack();
             }
-            _ = SpotifyClient.GetInstance().PlayItem(Uri);
+            _ = _spotifyClient.PlayItem(Uri);
         }
     }
 
     public class PausePlayResult : AbstractFontAwesomeQueryResult
     {
-        public PausePlayResult() : base("Play/pause current track")
-        {
+        private readonly SpotifyClient _spotifyClient;
 
+        public PausePlayResult(SpotifyClient spotifyClient) : base("Play/pause current track")
+        {
+            _spotifyClient = spotifyClient;
         }
 
         public override EFontAwesomeIcon FontAwesomeIcon => EFontAwesomeIcon.Brands_Spotify;
 
         public override void OnSelect()
         {
-            _ = SpotifyClient.GetInstance().PlayPauseCurrentTrack();
+            _ = _spotifyClient.PlayPauseCurrentTrack();
         }
     }
 
     public class QueueOption : AbstractFontAwesomeQueryResult
     {
-        public QueueOption(string result, string uri) : base(result)
+        private readonly SpotifyClient _spotifyClient;
+
+        public QueueOption(SpotifyClient spotifyClient, string result, string uri) : base(result)
         {
+            _spotifyClient = spotifyClient;
             Uri = uri;
         }
 
@@ -55,7 +62,7 @@ namespace PinPoint.Plugin.Spotify
 
         public override void OnSelect()
         {
-            _ = SpotifyClient.GetInstance().QueueItem(Uri);
+            _ = _spotifyClient.QueueItem(Uri);
         }
 
         public override EFontAwesomeIcon FontAwesomeIcon => EFontAwesomeIcon.Solid_List;

--- a/Pinpoint.Plugin.Spotify/UnauthenticatedResult.cs
+++ b/Pinpoint.Plugin.Spotify/UnauthenticatedResult.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using FontAwesome5;
+using Pinpoint.Core.Results;
+using Pinpoint.Plugin.Spotify.Client;
+
+namespace PinPoint.Plugin.Spotify
+{
+    public class UnauthenticatedResult : AbstractFontAwesomeQueryResult
+    {
+        private readonly AuthenticationManager _authenticationManager;
+        private readonly SpotifyClient _spotifyClient;
+
+        public UnauthenticatedResult(AuthenticationManager authenticationManager, SpotifyClient spotifyClient)
+        {
+            _authenticationManager = authenticationManager;    
+            _spotifyClient = spotifyClient;
+        }
+
+        public override EFontAwesomeIcon FontAwesomeIcon => throw new System.NotImplementedException();
+
+        public override void OnSelect()
+        {
+            Task.Run(async () => {
+                var tokens = await _authenticationManager.Authenticate();
+                if (tokens?.access_token != null && tokens.refresh_token != null)
+                {
+                    await _spotifyClient.InitializeClientWithTokens(tokens);
+                }
+            });
+        }
+    }
+}

--- a/Pinpoint.Plugin.Spotify/UnauthenticatedResult.cs
+++ b/Pinpoint.Plugin.Spotify/UnauthenticatedResult.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using FontAwesome5;
 using Pinpoint.Core.Results;
@@ -9,14 +10,16 @@ namespace PinPoint.Plugin.Spotify
     {
         private readonly AuthenticationManager _authenticationManager;
         private readonly SpotifyClient _spotifyClient;
+        private readonly Action _onAuthenticated;
 
-        public UnauthenticatedResult(AuthenticationManager authenticationManager, SpotifyClient spotifyClient)
+        public UnauthenticatedResult(AuthenticationManager authenticationManager, SpotifyClient spotifyClient, Action onAuthenticated) : base("Not signed in to Spotify", "Select this option to sign in.")
         {
-            _authenticationManager = authenticationManager;    
+            _authenticationManager = authenticationManager;
             _spotifyClient = spotifyClient;
+            _onAuthenticated = onAuthenticated;
         }
 
-        public override EFontAwesomeIcon FontAwesomeIcon => throw new System.NotImplementedException();
+        public override EFontAwesomeIcon FontAwesomeIcon => EFontAwesomeIcon.Brands_Spotify;
 
         public override void OnSelect()
         {
@@ -25,6 +28,7 @@ namespace PinPoint.Plugin.Spotify
                 if (tokens?.access_token != null && tokens.refresh_token != null)
                 {
                     await _spotifyClient.InitializeClientWithTokens(tokens);
+                    _onAuthenticated();
                 }
             });
         }


### PR DESCRIPTION
Previously, the Spotify plugin would just launch a browser and prompt for sign in if you wrote e.g. "play" and weren't signed in to Spotify.
Now, instead it just displays a result stating that you are not signed in to Spotify, and when you select that result, you are taken to the sign in page.
Also refactored a bit of code so the Spotify client no longer needs the hack where we set a public static property after initializing the plugin.